### PR TITLE
fix(nix): fix nix flake in macOS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1715063087,
+        "narHash": "sha256-cktPkcCmJ2sR0V/FaWEuCWmKuGPbwoMltih/EfF0mXg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f8f16c1f2c83bea4e51e6522d988ec8bfcc8420e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1715106818,
@@ -38,7 +59,25 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714936835,
+        "narHash": "sha256-M+PpgfRMBfHo8Jb2ou/s3maAZbps0XnuHXQU9Hv9vL0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "c4618fe14d39992fbbb85c2d6cad028a232c13d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,12 +5,17 @@
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
     crane,
+    fenix,
   }: let
     forEachSystem = nixpkgs.lib.genAttrs [
       "aarch64-darwin"
@@ -21,7 +26,7 @@
   in {
     packages = forEachSystem (system: let
       craneDerivations = nixpkgs.legacyPackages.${system}.callPackage ./nix/default.nix {
-        inherit crane;
+        inherit crane fenix;
       };
     in {
       default = craneDerivations.myCrate;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,14 +2,27 @@
   pkgs,
   system,
   crane,
+  fenix,
 }: let
-  craneLib = crane.lib.${system};
+  fenix-channel = fenix.packages.${system}.latest;
+  fenix-toolchain = fenix-channel.withComponents [
+    "cargo"
+    "clippy"
+    "rust-analyzer"
+    "rust-src"
+    "rustc"
+    "rustfmt"
+  ];
+
+  craneLib = crane.lib.${system}.overrideToolchain fenix-toolchain;
 
   # Common derivation arguments used for all builds
   commonArgs = {
     src = craneLib.cleanCargoSource ../.;
 
     nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+      pkgs.darwin.apple_sdk.frameworks.Security
+      pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
       pkgs.libiconv
     ];
   };
@@ -47,8 +60,10 @@
     });
 in {
   inherit
+    commonArgs
     myCrate
     myCrateClippy
     myCrateCoverage
+    fenix-toolchain
     ;
 }

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -20,6 +20,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1715063087,
+        "narHash": "sha256-cktPkcCmJ2sR0V/FaWEuCWmKuGPbwoMltih/EfF0mXg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f8f16c1f2c83bea4e51e6522d988ec8bfcc8420e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -133,8 +154,26 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714936835,
+        "narHash": "sha256-M+PpgfRMBfHo8Jb2ou/s3maAZbps0XnuHXQU9Hv9vL0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "c4618fe14d39992fbbb85c2d6cad028a232c13d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {


### PR DESCRIPTION
MacOS requires a specific library `liconv` to be present during the link stage of compiling rust programs. Though it seemed to be an input to the flake before this change, attempting to build on MacOS yeilded this error:

```
error: linking with `cc` failed: exit status: 1

...

= note: ld: library not found for -liconv
          clang-16: error: linker command failed with exit code 1 (use -v to see invocation)

error: could not compile `retry` (bin "retry") due to 1 previous error
```

This change updates the nix flake according to a working version in another repository which uses `fenix` to supply rust toolchains.

It resolves the error above, and adds `fenix` as a flake input.