### PR TITLE
feat: omitting up-to will retry indefinitely 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1715063087,
+        "narHash": "sha256-cktPkcCmJ2sR0V/FaWEuCWmKuGPbwoMltih/EfF0mXg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f8f16c1f2c83bea4e51e6522d988ec8bfcc8420e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1715106818,
@@ -38,7 +59,25 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714936835,
+        "narHash": "sha256-M+PpgfRMBfHo8Jb2ou/s3maAZbps0XnuHXQU9Hv9vL0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "c4618fe14d39992fbbb85c2d6cad028a232c13d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,12 +5,17 @@
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
     crane,
+    fenix,
   }: let
     forEachSystem = nixpkgs.lib.genAttrs [
       "aarch64-darwin"
@@ -21,7 +26,7 @@
   in {
     packages = forEachSystem (system: let
       craneDerivations = nixpkgs.legacyPackages.${system}.callPackage ./nix/default.nix {
-        inherit crane;
+        inherit crane fenix;
       };
     in {
       default = craneDerivations.myCrate;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,14 +2,27 @@
   pkgs,
   system,
   crane,
+  fenix,
 }: let
-  craneLib = crane.lib.${system};
+  fenix-channel = fenix.packages.${system}.latest;
+  fenix-toolchain = fenix-channel.withComponents [
+    "cargo"
+    "clippy"
+    "rust-analyzer"
+    "rust-src"
+    "rustc"
+    "rustfmt"
+  ];
+
+  craneLib = crane.lib.${system}.overrideToolchain fenix-toolchain;
 
   # Common derivation arguments used for all builds
   commonArgs = {
     src = craneLib.cleanCargoSource ../.;
 
     nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+      pkgs.darwin.apple_sdk.frameworks.Security
+      pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
       pkgs.libiconv
     ];
   };
@@ -47,8 +60,10 @@
     });
 in {
   inherit
+    commonArgs
     myCrate
     myCrateClippy
     myCrateCoverage
+    fenix-toolchain
     ;
 }

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -20,6 +20,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1715063087,
+        "narHash": "sha256-cktPkcCmJ2sR0V/FaWEuCWmKuGPbwoMltih/EfF0mXg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f8f16c1f2c83bea4e51e6522d988ec8bfcc8420e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -133,8 +154,26 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714936835,
+        "narHash": "sha256-M+PpgfRMBfHo8Jb2ou/s3maAZbps0XnuHXQU9Hv9vL0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "c4618fe14d39992fbbb85c2d6cad028a232c13d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,8 +52,9 @@ Retry for 100s: retry --up-to 100s ./foo"#,
 
 #[derive(Debug, Parser)]
 pub(crate) struct Cli {
-    // TODO: make this optional to indicate "retry forever"
     /// Retry constraint expressed in number of attempts or total duration.
+    ///
+    /// If omitted, the command will be retried indefinitely.
     ///
     /// Accepted format is:
     /// [0-9]+(x|ns|us|ms|[smhdwy])
@@ -67,7 +68,7 @@ pub(crate) struct Cli {
     /// retry --up-to 10m -- sh -c './download-new-publication && sleep 10s'
     /// ```
     #[arg(long, value_parser = Retry::from_str, help = "Retry constraint expressed in attempts or duration")]
-    pub up_to: Retry,
+    pub up_to: Option<Retry>,
 
     /// Timeout to enforce on each attempt.
     ///
@@ -129,7 +130,7 @@ mod tests {
     #[test]
     fn test_cli_up_to_retry_from_str() {
         let input = "3x";
-        let expected = Retry::NumberOfTimes(3);
+        let expected = Some(Retry::NumberOfTimes(3));
         let cli = Cli::parse_from(&["", "--up-to", input]);
         assert_eq!(cli.up_to, expected);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,3 +103,68 @@ async fn main() -> Result<()> {
     let args: Cli = Cli::parse();
     run_tasks(args.command, args.up_to, args.task_timeout).await
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_eval_success() {
+        let command = vec!["echo".to_string(), "echo_test_eval_success".to_string()];
+        let exit_status = eval(&command).await.unwrap();
+        assert_eq!(exit_status.success(), true);
+    }
+
+    #[tokio::test]
+    async fn test_eval_failure() {
+        let command = vec!["false".to_string()];
+        let exit_status = eval(&command).await.unwrap();
+        assert_eq!(exit_status.success(), false);
+    }
+
+    #[tokio::test]
+    async fn test_run_task_success() {
+        let command = vec!["echo".to_string(), "echo_test_run_task_success".to_string()];
+        let task_outcome = run_task(&command, None).await.unwrap();
+        assert_eq!(task_outcome, TaskOutcome::Success);
+    }
+
+    #[tokio::test]
+    async fn test_run_task_timeout() {
+        let command = vec!["sleep".to_string(), "10".to_string()];
+        let task_timeout = Some(Duration::from_secs(1));
+        let task_outcome = run_task(&command, task_timeout).await.unwrap();
+        assert_eq!(task_outcome, TaskOutcome::Timeout);
+    }
+
+    #[tokio::test]
+    async fn test_loop_task_success() {
+        let command = vec![
+            "echo".to_string(),
+            "echo_test_loop_task_success".to_string(),
+        ];
+        let task_timeout = Some(Duration::from_secs(5));
+        let task_outcome = loop_task(&command, task_timeout).await.unwrap();
+        assert_eq!(task_outcome, TaskOutcome::Success);
+    }
+
+    #[tokio::test]
+    async fn test_run_tasks_success() {
+        let command = vec![
+            "echo".to_string(),
+            "echo_test_run_tasks_success".to_string(),
+        ];
+        let up_to = Retry::NumberOfTimes(3);
+        let task_timeout = Some(Duration::from_secs(5));
+        let result = run_tasks(command, up_to, task_timeout).await;
+        assert_eq!(result.is_ok(), true);
+    }
+
+    #[tokio::test]
+    async fn test_run_tasks_failure() {
+        let command = vec!["false".to_string()];
+        let up_to = Retry::NumberOfTimes(3);
+        let task_timeout = Some(Duration::from_secs(5));
+        let result = run_tasks(command, up_to, task_timeout).await;
+        assert_eq!(result.is_err(), true);
+    }
+}


### PR DESCRIPTION
This change follows through with existing TODOs updating omission of
`up-to` to imply "retry until success".