### PR TITLE
feat: add stop-on-exit-code option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,3 +7,5 @@ on:
 jobs:
   test:
     uses: semantic-release-action/rust/.github/workflows/ci.yml@v5
+    with:
+      toolchain: nightly-2024-05-12

--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1715063087,
+        "narHash": "sha256-cktPkcCmJ2sR0V/FaWEuCWmKuGPbwoMltih/EfF0mXg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f8f16c1f2c83bea4e51e6522d988ec8bfcc8420e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1715106818,
@@ -38,7 +59,25 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714936835,
+        "narHash": "sha256-M+PpgfRMBfHo8Jb2ou/s3maAZbps0XnuHXQU9Hv9vL0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "c4618fe14d39992fbbb85c2d6cad028a232c13d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,12 +5,17 @@
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
     crane,
+    fenix,
   }: let
     forEachSystem = nixpkgs.lib.genAttrs [
       "aarch64-darwin"
@@ -21,7 +26,7 @@
   in {
     packages = forEachSystem (system: let
       craneDerivations = nixpkgs.legacyPackages.${system}.callPackage ./nix/default.nix {
-        inherit crane;
+        inherit crane fenix;
       };
     in {
       default = craneDerivations.myCrate;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,14 +2,27 @@
   pkgs,
   system,
   crane,
+  fenix,
 }: let
-  craneLib = crane.lib.${system};
+  fenix-channel = fenix.packages.${system}.latest;
+  fenix-toolchain = fenix-channel.withComponents [
+    "cargo"
+    "clippy"
+    "rust-analyzer"
+    "rust-src"
+    "rustc"
+    "rustfmt"
+  ];
+
+  craneLib = crane.lib.${system}.overrideToolchain fenix-toolchain;
 
   # Common derivation arguments used for all builds
   commonArgs = {
     src = craneLib.cleanCargoSource ../.;
 
     nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+      pkgs.darwin.apple_sdk.frameworks.Security
+      pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
       pkgs.libiconv
     ];
   };
@@ -51,5 +64,6 @@ in {
     myCrate
     myCrateClippy
     myCrateCoverage
+    fenix-toolchain
     ;
 }

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -20,6 +20,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1715063087,
+        "narHash": "sha256-cktPkcCmJ2sR0V/FaWEuCWmKuGPbwoMltih/EfF0mXg=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "f8f16c1f2c83bea4e51e6522d988ec8bfcc8420e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -133,8 +154,26 @@
     "root": {
       "inputs": {
         "crane": "crane",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1714936835,
+        "narHash": "sha256-M+PpgfRMBfHo8Jb2ou/s3maAZbps0XnuHXQU9Hv9vL0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "c4618fe14d39992fbbb85c2d6cad028a232c13d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/src/decider.rs
+++ b/src/decider.rs
@@ -1,0 +1,292 @@
+use std::{collections::HashSet, process::ExitStatus};
+
+use crate::task::TaskOutcome;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Decider {
+    Default(DefaultDecider),
+    RetryOnExitCodes(RetryOnExitCodesDecider),
+}
+
+impl Decider {
+    pub(crate) fn new(retry_on_exit_codes: Option<Vec<i32>>) -> Self {
+        retry_on_exit_codes.into()
+    }
+}
+
+impl Default for Decider {
+    fn default() -> Self {
+        Decider::Default(DefaultDecider::default())
+    }
+}
+
+impl Decidable for Decider {
+    fn decide(&self, task_outcome: TaskOutcome) -> Decision {
+        match self {
+            Decider::Default(decider) => decider.decide(task_outcome),
+            Decider::RetryOnExitCodes(decider) => decider.decide(task_outcome),
+        }
+    }
+}
+
+impl From<Option<Vec<i32>>> for Decider {
+    fn from(retry_on_exit_codes: Option<Vec<i32>>) -> Self {
+        match retry_on_exit_codes {
+            Some(retry_on_exit_codes) => Decider::RetryOnExitCodes(RetryOnExitCodesDecider::new(
+                retry_on_exit_codes.into_iter().collect(),
+            )),
+            None => Decider::Default(DefaultDecider::new()),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DefaultDecider;
+
+impl DefaultDecider {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RetryOnExitCodesDecider(HashSet<i32>);
+
+impl RetryOnExitCodesDecider {
+    fn new(retry_on_exit_codes: HashSet<i32>) -> Self {
+        Self(retry_on_exit_codes.into())
+    }
+}
+
+pub trait Decidable {
+    fn decide(&self, task_outcome: TaskOutcome) -> Decision;
+}
+
+impl Decidable for DefaultDecider {
+    fn decide(&self, task_outcome: TaskOutcome) -> Decision {
+        match task_outcome {
+            TaskOutcome::Success => Decision::Finished(FinishedReason::Success),
+            TaskOutcome::Failure(exit_code) => {
+                Decision::Unfinished(UnfinishedReason::Failure(exit_code))
+            }
+            TaskOutcome::Terminated(signal) => {
+                Decision::Finished(FinishedReason::Terminated(signal))
+            }
+            TaskOutcome::TimeoutExceeded => Decision::Unfinished(UnfinishedReason::Timeout),
+        }
+    }
+}
+
+impl Decidable for RetryOnExitCodesDecider {
+    fn decide(&self, task_outcome: TaskOutcome) -> Decision {
+        match task_outcome {
+            TaskOutcome::Success => Decision::Finished(FinishedReason::Success),
+            TaskOutcome::Failure(exit_status) => {
+                if self.0.contains(
+                    &exit_status
+                        .code()
+                        .expect("TaskOutcome::Failure(ExitStatus) will never have a None ExitCode"),
+                ) {
+                    Decision::Unfinished(UnfinishedReason::Failure(exit_status))
+                } else {
+                    Decision::Finished(FinishedReason::Failure(exit_status))
+                }
+            }
+            TaskOutcome::Terminated(signal) => {
+                Decision::Finished(FinishedReason::Terminated(signal))
+            }
+            TaskOutcome::TimeoutExceeded => Decision::Unfinished(UnfinishedReason::Timeout),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Decision {
+    Finished(FinishedReason),
+    Unfinished(UnfinishedReason),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FinishedReason {
+    Success,
+    Failure(ExitStatus),
+    Terminated(ExitStatus),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnfinishedReason {
+    Failure(ExitStatus),
+    Timeout,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::process::ExitStatusExt;
+
+    use crate::task::{Runnable, Task};
+
+    use super::*;
+
+    pub(crate) struct TestTask(TaskOutcome);
+
+    impl Runnable for TestTask {
+        // eval must be defined, but is unused
+        async fn eval(&self) -> std::io::Result<ExitStatus> {
+            Ok(ExitStatus::default())
+        }
+
+        async fn run(&self) -> std::io::Result<TaskOutcome> {
+            Ok(self.0)
+        }
+    }
+
+    #[test]
+    fn default_decider_success() {
+        // Arrange
+        let decider = Decider::new(None);
+
+        // Act
+        let conclusion = decider.decide(TaskOutcome::Success);
+
+        // Assert
+        assert_eq!(conclusion, Decision::Finished(FinishedReason::Success));
+    }
+
+    #[test]
+    fn default_decider_failure() {
+        // Arrange
+        let exit_code = ExitStatus::from_raw(1);
+        let task_outcome = TaskOutcome::Failure(exit_code.clone());
+        let decider = Decider::new(None);
+
+        // Act
+        let conclusion = decider.decide(task_outcome);
+
+        // Assert
+        assert_eq!(
+            conclusion,
+            Decision::Unfinished(UnfinishedReason::Failure(exit_code))
+        );
+    }
+
+    #[test]
+    fn default_decider_termination() {
+        // Arrange
+        let exit_code = ExitStatus::from_raw(1);
+        let task_outcome = TaskOutcome::Terminated(exit_code);
+        let decider = Decider::new(None);
+
+        // Act
+        let conclusion = decider.decide(task_outcome);
+
+        // Assert
+        assert_eq!(
+            conclusion,
+            Decision::Finished(FinishedReason::Terminated(exit_code))
+        );
+    }
+
+    #[test]
+    fn default_decider_timeout() {
+        // Arrange
+        let task_outcome = TaskOutcome::TimeoutExceeded;
+        let decider = Decider::new(None);
+
+        // Act
+        let conclusion = decider.decide(task_outcome);
+
+        // Assert
+        assert_eq!(conclusion, Decision::Unfinished(UnfinishedReason::Timeout));
+    }
+
+    #[test]
+    fn retry_on_exit_codes_decider_success() {
+        // Arrange
+        // explicit empty set means it will never retry
+        let decider = Decider::new(Some(Vec::new()));
+
+        // Act
+        let conclusion = decider.decide(TaskOutcome::Success);
+
+        // Assert
+        assert_eq!(conclusion, Decision::Finished(FinishedReason::Success));
+    }
+
+    #[tokio::test]
+    async fn retry_on_exit_codes_decider_unfinished_failure() {
+        // Arrange
+        let task = Task::new(
+            vec!["sh".to_string(), "-c".to_string(), "exit 2".to_string()],
+            None,
+        );
+        let task_outcome = task.run().await.unwrap();
+        let task_outcome_exit_status = match task_outcome {
+            TaskOutcome::Failure(exit_status) => exit_status,
+            _ => panic!("Expected TaskOutcome::Failure"),
+        };
+        let retry_on_exit_codes = Some(vec![1, 2, 3]);
+        let decider = Decider::new(retry_on_exit_codes);
+
+        // Act
+        let conclusion = decider.decide(task_outcome);
+
+        // Assert
+        assert_eq!(
+            conclusion,
+            Decision::Unfinished(UnfinishedReason::Failure(task_outcome_exit_status))
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_on_exit_codes_decider_finished_failure() {
+        // Arrange
+        let task = Task::new(
+            vec!["sh".to_string(), "-c".to_string(), "exit 4".to_string()],
+            None,
+        );
+        let task_outcome = task.run().await.unwrap();
+        let task_outcome_exit_status = match task_outcome {
+            TaskOutcome::Failure(exit_status) => exit_status,
+            _ => panic!("Expected TaskOutcome::Failure"),
+        };
+        let retry_on_exit_codes = Some(vec![1, 2, 3]);
+        let decider = Decider::new(retry_on_exit_codes);
+
+        // Act
+        let conclusion = decider.decide(task_outcome);
+
+        // Assert
+        assert_eq!(
+            conclusion,
+            Decision::Finished(FinishedReason::Failure(task_outcome_exit_status))
+        );
+    }
+
+    #[test]
+    fn retry_on_exit_codes_decider_termination() {
+        // Arrange
+        // explicit empty set means it will never retry
+        let decider = Decider::new(Some(Vec::new()));
+        let exit_code = ExitStatus::from_raw(1);
+        let task_outcome = TaskOutcome::Terminated(exit_code);
+        let conclusion = decider.decide(task_outcome);
+        assert_eq!(
+            conclusion,
+            Decision::Finished(FinishedReason::Terminated(exit_code))
+        );
+    }
+
+    #[test]
+    fn retry_on_exit_codes_decider_timeout() {
+        // Arrange
+        let retry_on_exit_codes = vec![]; // explicit empty set means it will never retry
+        let decider = RetryOnExitCodesDecider::new(retry_on_exit_codes.into_iter().collect());
+        let task_outcome = TaskOutcome::TimeoutExceeded;
+
+        // Act
+        let conclusion = decider.decide(task_outcome);
+
+        // Assert
+        assert_eq!(conclusion, Decision::Unfinished(UnfinishedReason::Timeout));
+    }
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,351 @@
+use std::process::ExitStatus;
+
+use tokio::time::{error::Elapsed, Duration};
+
+use crate::cli::Retry;
+use crate::decider::{Decidable, Decision, FinishedReason, UnfinishedReason};
+use crate::task::Runnable;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Executor<T, D>
+where
+    T: Runnable,
+    D: Decidable,
+{
+    task: T,
+    decider: D,
+    limit: Limit,
+}
+
+impl<T, D> Executor<T, D>
+where
+    T: Runnable,
+    D: Decidable,
+{
+    pub(crate) fn new(task: T, decider: D, limit: Limit) -> Self {
+        Self {
+            task,
+            decider,
+            limit,
+        }
+    }
+}
+
+pub(crate) trait Executable {
+    async fn execute(&self) -> std::io::Result<ExecutionOutcome>;
+    async fn run_indefinitely(&self) -> std::io::Result<FinishedReason>;
+}
+
+impl<T, D> Executable for Executor<T, D>
+where
+    T: Runnable,
+    D: Decidable,
+{
+    async fn execute(&self) -> std::io::Result<ExecutionOutcome> {
+        let limit = Limit::from(self.limit);
+        let mut final_unfinished_reason = UnfinishedReason::Timeout;
+        Ok(match limit {
+            Limit::NumberOfTimes(num_times) => {
+                for _ in 0..num_times {
+                    let task_outcome = self.task.run().await?;
+                    let decision = self.decider.decide(task_outcome);
+                    match decision {
+                        Decision::Finished(finished_reason) => return Ok(finished_reason.into()),
+                        Decision::Unfinished(unfinished_reason) => {
+                            final_unfinished_reason = unfinished_reason;
+                            continue;
+                        }
+                    }
+                }
+                ExecutionOutcome::Exhausted(ExhaustionReason::RetryTimesExceeded(
+                    final_unfinished_reason,
+                ))
+            }
+            Limit::ForDuration(duration) => {
+                let task_result_or_timeout: Result<std::io::Result<FinishedReason>, Elapsed> =
+                    tokio::time::timeout(duration, self.run_indefinitely()).await;
+                match task_result_or_timeout {
+                    Ok(finished_reason) => finished_reason?.into(),
+                    // retry up_to duration exceeded
+                    Err(_timeout) => ExecutionOutcome::Exhausted(
+                        ExhaustionReason::RetryTimeoutExceeded(UnfinishedReason::Timeout),
+                    ),
+                }
+            }
+        })
+    }
+
+    async fn run_indefinitely(&self) -> std::io::Result<FinishedReason> {
+        loop {
+            let task_outcome = self.task.run().await?;
+            let decision = self.decider.decide(task_outcome);
+            match decision {
+                Decision::Finished(finished_reason) => return Ok(finished_reason),
+                Decision::Unfinished(_) => {
+                    tokio::task::yield_now().await;
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ExecutionOutcome {
+    Success,                     // The command succeeded
+    Failure(ExitStatus), // The command failed and was not retried because the exit code was not in the retry_on_exit_codes set
+    Terminated(ExitStatus), // The command was terminated by a signal
+    Exhausted(ExhaustionReason), // The command was retried until the up_to limit
+}
+
+impl From<FinishedReason> for ExecutionOutcome {
+    fn from(finished_reason: FinishedReason) -> Self {
+        match finished_reason {
+            FinishedReason::Success => ExecutionOutcome::Success,
+            FinishedReason::Terminated(exit_status) => ExecutionOutcome::Terminated(exit_status),
+            FinishedReason::Failure(exit_status) => ExecutionOutcome::Failure(exit_status),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ExhaustionReason {
+    RetryTimesExceeded(UnfinishedReason),
+    RetryTimeoutExceeded(UnfinishedReason),
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum Limit {
+    ForDuration(Duration),
+    NumberOfTimes(u64),
+}
+
+impl From<Retry> for Limit {
+    fn from(retry: Retry) -> Self {
+        match retry {
+            Retry::ForDuration(duration) => Limit::ForDuration(duration),
+            Retry::NumberOfTimes(num_times) => Limit::NumberOfTimes(num_times),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::process::ExitStatusExt;
+    use tokio::time::Duration;
+
+    use super::*;
+    use crate::task::TaskOutcome;
+
+    struct DummyTask;
+
+    impl Runnable for DummyTask {
+        async fn eval(&self) -> std::io::Result<ExitStatus> {
+            Ok(ExitStatus::from_raw(0))
+        }
+        async fn run(&self) -> std::io::Result<TaskOutcome> {
+            Ok(TaskOutcome::Success)
+        }
+    }
+
+    struct TestDecider(Decision);
+
+    impl TestDecider {
+        fn new(conclusion: Decision) -> Self {
+            Self(conclusion)
+        }
+    }
+
+    impl Decidable for TestDecider {
+        fn decide(&self, _task_outcome: TaskOutcome) -> Decision {
+            self.0
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_retry_times_finished_success() {
+        // Arrange
+        let decider = TestDecider(Decision::Finished(FinishedReason::Success));
+        let limit = Limit::NumberOfTimes(3);
+        let executor = Executor::new(DummyTask, decider, limit);
+
+        // Act
+        let outcome = executor.execute().await.unwrap();
+
+        // Assert
+        assert_eq!(outcome, ExecutionOutcome::Success);
+    }
+
+    #[tokio::test]
+    async fn execute_retry_times_finished_failure() {
+        // Arrange
+        let failure_exit_status = ExitStatus::from_raw(1);
+        let decider = TestDecider(Decision::Finished(FinishedReason::Failure(
+            failure_exit_status.clone(),
+        )));
+        let limit = Limit::NumberOfTimes(3);
+        let executor = Executor::new(DummyTask, decider, limit);
+
+        // Act
+        let outcome = executor.execute().await.unwrap();
+
+        // Assert
+        assert_eq!(outcome, ExecutionOutcome::Failure(failure_exit_status));
+    }
+
+    #[tokio::test]
+    async fn execute_retry_times_finished_terminated() {
+        // Arrange
+        let failure_exit_status = ExitStatus::from_raw(1);
+        let decider = TestDecider(Decision::Finished(FinishedReason::Terminated(
+            failure_exit_status.clone(),
+        )));
+        let limit = Limit::NumberOfTimes(3);
+        let executor = Executor::new(DummyTask, decider, limit);
+
+        // Act
+        let outcome = executor.execute().await.unwrap();
+
+        // Assert
+        assert_eq!(outcome, ExecutionOutcome::Terminated(failure_exit_status));
+    }
+
+    #[tokio::test]
+    async fn execute_retry_times_unfinished_failure() {
+        // Arrange
+        let failure_exit_status = ExitStatus::from_raw(1);
+        let decider = TestDecider(Decision::Unfinished(UnfinishedReason::Failure(
+            failure_exit_status.clone(),
+        )));
+        let limit = Limit::NumberOfTimes(3);
+        let executor = Executor::new(DummyTask, decider, limit);
+
+        // Act
+        let outcome = executor.execute().await.unwrap();
+
+        // Assert
+        assert_eq!(
+            outcome,
+            ExecutionOutcome::Exhausted(ExhaustionReason::RetryTimesExceeded(
+                UnfinishedReason::Failure(failure_exit_status)
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_retry_times_unfinished_timeout() {
+        // Arrange
+        let decider = TestDecider(Decision::Unfinished(UnfinishedReason::Timeout));
+        let limit = Limit::NumberOfTimes(3);
+        let executor = Executor::new(DummyTask, decider, limit);
+
+        // Act
+        let outcome = executor.execute().await.unwrap();
+
+        // Assert
+        assert_eq!(
+            outcome,
+            ExecutionOutcome::Exhausted(ExhaustionReason::RetryTimesExceeded(
+                UnfinishedReason::Timeout
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_retry_timeout_finished_success() {
+        // Arrange
+        let decider = TestDecider(Decision::Finished(FinishedReason::Success));
+        let limit = Limit::ForDuration(Duration::from_millis(10));
+        let executor = Executor::new(DummyTask, decider, limit);
+
+        // Act
+        let outcome = executor.execute().await.unwrap();
+
+        // Assert
+        assert_eq!(outcome, ExecutionOutcome::Success);
+    }
+
+    #[tokio::test]
+    async fn execute_retry_timeout_finished_failure() {
+        // Arrange
+        let failure_exit_status = ExitStatus::from_raw(1);
+        let decider = TestDecider(Decision::Finished(FinishedReason::Failure(
+            failure_exit_status.clone(),
+        )));
+        let limit = Limit::ForDuration(Duration::from_millis(10));
+        let executor = Executor::new(DummyTask, decider, limit);
+
+        // Act
+        let outcome = executor.execute().await.unwrap();
+
+        // Assert
+        assert_eq!(outcome, ExecutionOutcome::Failure(failure_exit_status));
+    }
+
+    #[tokio::test]
+    async fn execute_retry_timeout_finished_terminated() {
+        // Arrange
+        let failure_exit_status = ExitStatus::from_raw(1);
+        let decider = TestDecider(Decision::Finished(FinishedReason::Terminated(
+            failure_exit_status.clone(),
+        )));
+        let limit = Limit::ForDuration(Duration::from_millis(10));
+        let executor = Executor::new(DummyTask, decider, limit);
+
+        // Act
+        let outcome = executor.execute().await.unwrap();
+
+        // Assert
+        assert_eq!(outcome, ExecutionOutcome::Terminated(failure_exit_status));
+    }
+
+    #[tokio::test]
+    async fn execute_retry_timeout_unfinished_failure() {
+        // Arrange
+        let failure_exit_status = ExitStatus::from_raw(1);
+
+        let decider = TestDecider::new(Decision::Unfinished(UnfinishedReason::Failure(
+            failure_exit_status.clone(),
+        )));
+        let limit = Limit::ForDuration(Duration::from_millis(5));
+        let executor: Executor<DummyTask, TestDecider> = Executor::new(DummyTask, decider, limit);
+
+        // Act
+        let outcome = executor.execute().await.unwrap();
+
+        // Assert
+        assert_eq!(
+            outcome,
+            ExecutionOutcome::Exhausted(ExhaustionReason::RetryTimeoutExceeded(
+                UnfinishedReason::Timeout
+            ))
+        );
+        // Because the task races with a duration, there is no way to return an
+        // ExitStatus and so no way that it can ever be an UnfinishedReason::Failure
+        assert_ne!(
+            outcome,
+            ExecutionOutcome::Exhausted(ExhaustionReason::RetryTimeoutExceeded(
+                UnfinishedReason::Failure(failure_exit_status)
+            ))
+        )
+    }
+
+    #[tokio::test]
+    async fn execute_retry_timeout_unfinished_timeout() {
+        // Arrange
+        let decider = TestDecider(Decision::Unfinished(UnfinishedReason::Timeout));
+        let limit = Limit::ForDuration(tokio::time::Duration::from_millis(5));
+        let executor = Executor::new(DummyTask, decider, limit);
+
+        // Act
+        let outcome = executor.execute().await.unwrap();
+
+        // Assert
+        assert_eq!(
+            outcome,
+            ExecutionOutcome::Exhausted(ExhaustionReason::RetryTimeoutExceeded(
+                UnfinishedReason::Timeout
+            ))
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,180 +1,50 @@
 #![forbid(unsafe_code)]
 #![deny(warnings, missing_docs)]
+#![feature(exit_status_error)]
 
 //! TODO: document me
 
-use std::{process::ExitStatus, time::Duration};
+use std::os::unix::process::ExitStatusExt;
+use std::process::ExitStatus;
 
 use clap::Parser;
-use cli::Cli;
-use tokio::process::Command;
 
 mod cli;
+mod decider;
+mod executor;
+mod task;
+mod types;
 
-use crate::cli::Retry;
+use crate::cli::Cli;
+use crate::decider::{Decider, UnfinishedReason};
+use crate::executor::{Executable, ExecutionOutcome, Executor, ExhaustionReason};
+use crate::task::Task;
+use crate::types::Result;
 
 // Notable: https://docs.rs/retry/latest/retry/
 
-type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-type Result<T> = std::result::Result<T, Error>;
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum TaskOutcome {
-    Success,
-    Timeout,
-}
-
-async fn eval(command: &[String]) -> Result<ExitStatus> {
-    // FIXME: kill in a way that guarantees reaping the child:
-    // https://docs.rs/tokio/latest/tokio/process/struct.Command.html#caveats
-    let mut child = Command::new(command[0].clone());
-    for argument in command.iter().skip(1) {
-        child.arg(argument);
-    }
-    let mut child = child.kill_on_drop(true).spawn()?;
-
-    Ok(child.wait().await?)
-}
-
-async fn run_task(command: &[String], task_timeout: Option<Duration>) -> Result<TaskOutcome> {
-    let status_code = match task_timeout {
-        None => eval(command).await?.code(),
-        Some(task_timeout) => {
-            let task = tokio::time::timeout(task_timeout, eval(command)).await;
-
-            match task {
-                // The command completed
-                Ok(result_exit_status) => match result_exit_status {
-                    Ok(exit_status) => exit_status.code(),
-                    Err(_eval_err) => None,
-                },
-                // The command timed out
-                Err(_timeout_err) => None,
-            }
-        }
-    };
-
-    if let Some(status_code) = status_code {
-        if status_code == 0 {
-            return Ok(TaskOutcome::Success);
-        }
-    }
-
-    Ok(TaskOutcome::Timeout)
-}
-
-async fn loop_task(command: &[String], task_timeout: Option<Duration>) -> Result<TaskOutcome> {
-    loop {
-        let status_code = run_task(command, task_timeout).await?;
-        if status_code == TaskOutcome::Success {
-            return Ok(TaskOutcome::Success);
-        }
-    }
-}
-
-async fn run_tasks(
-    command: Vec<String>,
-    up_to: Retry,
-    task_timeout: Option<Duration>,
-) -> Result<()> {
-    match up_to {
-        Retry::ForDuration(duration) => {
-            let task_outcome =
-                tokio::time::timeout(duration, loop_task(&command, task_timeout)).await;
-            if let Ok(Ok(TaskOutcome::Success)) = task_outcome {
-                return Ok(());
-            }
-        }
-        Retry::NumberOfTimes(num_times) => {
-            for _ in 0..num_times {
-                let task_outcome = run_task(&command, task_timeout).await?;
-                if task_outcome == TaskOutcome::Success {
-                    return Ok(());
-                }
-            }
-        }
-    };
-
-    Err("Command did not succeed within designated bounds".into())
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args: Cli = Cli::parse();
-    run_tasks(args.command, args.up_to, args.task_timeout).await
-}
-#[cfg(test)]
-mod tests {
-    use super::*;
+    let args = Cli::parse();
 
-    #[tokio::test]
-    async fn test_eval_success() {
-        let command = vec!["true".to_owned()];
-        let exit_status = eval(&command).await.unwrap();
-        assert_eq!(exit_status.success(), true);
-    }
-
-    #[tokio::test]
-    async fn test_eval_failure() {
-        let command = vec!["false".to_owned()];
-        let exit_status = eval(&command).await.unwrap();
-        assert_eq!(exit_status.success(), false);
-    }
-
-    #[tokio::test]
-    async fn test_run_task_success() {
-        let command = vec!["true".to_owned()];
-        let task_outcome = run_task(&command, None).await.unwrap();
-        assert_eq!(task_outcome, TaskOutcome::Success);
-    }
-
-    #[tokio::test]
-    async fn test_run_task_failure() {
-        let command = vec!["false".to_owned()];
-        let task_outcome = run_task(&command, None).await.unwrap();
-        assert_eq!(task_outcome, TaskOutcome::Timeout);
-    }
-
-    #[tokio::test]
-    async fn test_run_task_timeout() {
-        let command = vec!["sleep".to_owned(), "10".to_owned()];
-        let task_timeout = Some(Duration::from_secs(1));
-        let task_outcome = run_task(&command, task_timeout).await.unwrap();
-        assert_eq!(task_outcome, TaskOutcome::Timeout);
-    }
-
-    #[tokio::test]
-    async fn test_loop_task_success() {
-        let command = vec!["true".to_owned()];
-        let task_timeout = Some(Duration::from_secs(5));
-        let task_outcome = loop_task(&command, task_timeout).await.unwrap();
-        assert_eq!(task_outcome, TaskOutcome::Success);
-    }
-
-    #[tokio::test]
-    async fn test_run_tasks_success() {
-        let command = vec!["true".to_owned()];
-        let up_to = Retry::NumberOfTimes(3);
-        let task_timeout = Some(Duration::from_secs(5));
-        let result = run_tasks(command, up_to, task_timeout).await;
-        assert_eq!(result.is_ok(), true);
-    }
-
-    #[tokio::test]
-    async fn test_run_tasks_failure() {
-        let command = vec!["false".to_owned()];
-        let up_to = Retry::NumberOfTimes(3);
-        let task_timeout = Some(Duration::from_secs(5));
-        let result = run_tasks(command, up_to, task_timeout).await;
-        assert_eq!(result.is_err(), true);
-    }
-
-    #[tokio::test]
-    async fn test_run_tasks_timeout() {
-        let command = vec!["sleep".to_owned(), "10".to_owned()];
-        let up_to = Retry::ForDuration(Duration::from_secs(5));
-        let task_timeout = Some(Duration::from_secs(1));
-        let result = run_tasks(command, up_to, task_timeout).await;
-        assert_eq!(result.is_err(), true);
-    }
+    let task = Task::new(args.command, args.task_timeout);
+    let decider = Decider::new(args.on_exit_code);
+    let executor = Executor::new(task, decider, args.up_to.into());
+    let retry_outcome = executor.execute().await?;
+    Ok(match retry_outcome {
+        ExecutionOutcome::Success => Ok(()),
+        ExecutionOutcome::Failure(exit_status) => exit_status.exit_ok().map_err(Box::new),
+        ExecutionOutcome::Terminated(exit_status) => exit_status.exit_ok().map_err(Box::new),
+        ExecutionOutcome::Exhausted(exhaustion_reason) => match exhaustion_reason {
+            ExhaustionReason::RetryTimesExceeded(unfinished_reason)
+            | ExhaustionReason::RetryTimeoutExceeded(unfinished_reason) => {
+                match unfinished_reason {
+                    UnfinishedReason::Failure(exit_code) => exit_code.exit_ok().map_err(Box::new),
+                    UnfinishedReason::Timeout => {
+                        ExitStatus::from_raw(1).exit_ok().map_err(Box::new)
+                    }
+                }
+            }
+        },
+    }?)
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,117 @@
+use std::process::ExitStatus;
+use tokio::{process::Command, time::Duration};
+
+pub(crate) trait Runnable {
+    async fn eval(&self) -> std::io::Result<ExitStatus>;
+    async fn run(&self) -> std::io::Result<TaskOutcome>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Task {
+    command: Vec<String>,
+    task_timeout: Option<Duration>,
+}
+
+impl Task {
+    pub(crate) fn new(command: Vec<String>, task_timeout: Option<Duration>) -> Self {
+        Self {
+            command,
+            task_timeout,
+        }
+    }
+}
+
+impl Runnable for Task {
+    async fn eval(&self) -> std::io::Result<ExitStatus> {
+        // FIXME: kill in a way that guarantees reaping the child:
+        // https://docs.rs/tokio/latest/tokio/process/struct.Command.html#caveats
+        let mut child = Command::new(&self.command[0]);
+        for argument in self.command.iter().skip(1) {
+            child.arg(argument);
+        }
+        let mut child = child.kill_on_drop(true).spawn()?;
+
+        Ok(child.wait().await?)
+    }
+
+    async fn run(&self) -> std::io::Result<TaskOutcome> {
+        Ok(match self.task_timeout {
+            Some(task_timeout) => {
+                match tokio::time::timeout(task_timeout, self.eval()).await {
+                    // task completed
+                    Ok(task_result) => Some(task_result?),
+                    // task timed out
+                    Err(_timeout) => None,
+                }
+            }
+            None => Some(self.eval().await?),
+        }
+        .into())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TaskOutcome {
+    Success,
+    Failure(ExitStatus),
+    Terminated(ExitStatus),
+    TimeoutExceeded,
+}
+
+impl From<Option<ExitStatus>> for TaskOutcome {
+    fn from(status: Option<ExitStatus>) -> Self {
+        match status {
+            Some(status) => match status.code() {
+                Some(code) => match code {
+                    // exited with code 0
+                    0 => TaskOutcome::Success,
+                    // exited with code
+                    _ => TaskOutcome::Failure(status),
+                },
+                // terminated by signal
+                None => TaskOutcome::Terminated(status),
+            },
+            // did not terminate
+            None => TaskOutcome::TimeoutExceeded,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn task_success() {
+        let command = vec!["sh".to_string(), "-c".to_string(), "exit 0".to_string()];
+        let task = Task::new(command, None);
+        let outcome = task.run().await.unwrap();
+        assert_eq!(outcome, TaskOutcome::Success);
+    }
+
+    #[tokio::test]
+    async fn task_failure() {
+        let command = vec!["sh".to_string(), "-c".to_string(), "exit 144".to_string()];
+        let task = Task::new(command, None);
+        let outcome = task.run().await;
+        let outcome_exit_status_code = match outcome {
+            Ok(outcome) => match outcome {
+                TaskOutcome::Failure(exit_status) => match exit_status.code() {
+                    Some(code) => code,
+                    None => panic!("Expected ExitStatus::code() to return Some(_)"),
+                },
+                _ => panic!("Expected TaskOutcome::Failure"),
+            },
+            _ => panic!("Expected Ok(_)"),
+        };
+        assert_eq!(outcome_exit_status_code, 144);
+    }
+
+    #[tokio::test]
+    async fn task_timeout_exceeded() {
+        let command = vec!["sleep".to_string(), "0.05".to_string()];
+        let task = Task::new(command, Some(Duration::from_millis(1)));
+        let outcome = task.run().await.unwrap();
+        assert_eq!(outcome, TaskOutcome::TimeoutExceeded);
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,2 @@
+pub(crate) type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub(crate) type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
### Commit 1
This change adds `fenix` to the nix flake to enable the use of nightly
toolchains.

Using nightly rust toolchains enables the use of the features behind the
`exit_status_error`[^1] feature flag, which allows the use of
`ExitStatusError`[^2].

[^1]: https://github.com/rust-lang/rust/issues/84908
[^2]: https://doc.rust-lang.org/std/process/struct.ExitStatusError.html

### Commit 2
This commit refactors `retry` substantially. In doing so, tests cover
more of the system and several components with orthogonal conserns now
exist. These include:

 * Tasks
 * Deciders
 * Executors

Tasks own the actual running of the command passed to `retry`. They
generate `TaskOutcome`s which enumerate the ways a task can complete:

 * Success
 * Failure
 * Terminated
 * TimeoutExceeded

Deciders take these `TaskOutcome`s and decide if the task should be
retried or if it is `Finished`. Finished tasks cause the Executor to exit
early, while `Unfinished` tasks indicate that the Executor should retry
this task if it can.

The Executor controls how long or how many times a task should be
retried.

This refactor was instrumental in propigating `ExitStatus`s correctly
and will be invaluable when adding linear rate limiting to the Executor.