### PR TITLE
ci: use nightly toolchain to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,3 +17,4 @@ jobs:
     uses: semantic-release-action/rust/.github/workflows/release-binary.yml@v5
     with:
       disable-semantic-release-cargo: true
+      toolchain: nightly-2024-05-12


### PR DESCRIPTION
This hard codes the nightly toolchain to release from. As a follow-up, the nix flake should be used to source this value.