### PR TITLE
ci: make ci consistent with release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,4 @@ jobs:
   test:
     uses: semantic-release-action/rust/.github/workflows/ci.yml@v5
     with:
-      toolchain: nightly-2024-05-12
+      toolchain: nightly


### PR DESCRIPTION
During release, `nightly` toolchain is used. All workflows should use the same toolchain.